### PR TITLE
Build with native Sqlite3 lib and add macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ include
 lib
 icu
 *.xcframework
+.DS_Store
+libspatialite.xcframework.zip

--- a/.gitignore
+++ b/.gitignore
@@ -17,17 +17,18 @@
 *.app
 
 # Downloaded and built directories
-build
-include
-geos
-proj
-spatialite
-sqlite3
-rttopo
-include
-include
-lib
-icu
+/build/
+/include/
+/geos/
+/proj/
+/spatialite/
+/sqlite3/
+/rttopo/
+/include/
+/include/
+/lib/
+/icu/
 *.xcframework
 .DS_Store
 libspatialite.xcframework.zip
+*.xcuserstate

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,9 @@ all: build_arches
 # Build separate architectures
 # see https://www.innerfence.com/howto/apple-ios-devices-dates-versions-instruction-sets
 build_arches:
-	${MAKE} arch IOS_ARCH=x86_64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=x86_64-apple-darwin IOS_TARGET=x86_64-apple-ios8.0-simulator IOS_ARCH_DIR=x86_64
-	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneOS IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios8.0 IOS_ARCH_DIR=arm64-ios
-	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios8.0-simulator IOS_ARCH_DIR=arm64-sim
-	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios8.0-simulator IOS_ARCH_DIR=arm64-sim
+	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneOS IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0 IOS_ARCH_DIR=arm64-ios
+	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0-simulator IOS_ARCH_DIR=arm64-sim
+	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0-simulator IOS_ARCH_DIR=arm64-sim
 
 
 
@@ -29,9 +28,9 @@ UTHASHDIR = ${CURDIR}/uthash
 
 CXX = ${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++
 CC = ${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
-CFLAGS =-target ${IOS_TARGET} -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -mios-version-min=8.0 -Os -fembed-bitcode
-CXXFLAGS =-target ${IOS_TARGET} -stdlib=libc++ -std=c++11 -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -mios-version-min=8.0 -Os -fembed-bitcode
-LDFLAGS =-stdlib=libc++ -isysroot ${IOS_SDK} -L${LIBDIR} -L${IOS_SDK}/usr/lib -arch ${IOS_ARCH} -mios-version-min=8.0
+CFLAGS =-target ${IOS_TARGET} -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -mios-version-min=17.0 -Os -fembed-bitcode
+CXXFLAGS =-target ${IOS_TARGET} -stdlib=libc++ -std=c++11 -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -mios-version-min=17.0 -Os -fembed-bitcode
+LDFLAGS =-stdlib=libc++ -isysroot ${IOS_SDK} -L${LIBDIR} -L${IOS_SDK}/usr/lib -arch ${IOS_ARCH} -mios-version-min=17.0
 
 arch: ${LIBDIR}/libspatialite.a
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: build_arches
 build_arches:
 	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=MacOSX OSX_HOST=arm-apple-darwin OSX_TARGET=arm64-apple-macos12.0 IOS_ARCH_DIR=arm64-macos OS_TARGET=Darwin
 	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneOS IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0 IOS_ARCH_DIR=arm64-ios OS_TARGET=iOS
-#	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0-simulator IOS_ARCH_DIR=arm64-sim OS_TARGET=iOS
+	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0-simulator IOS_ARCH_DIR=arm64-sim OS_TARGET=iOS
 
 BUILD_DIR = ${CURDIR}/build
 PREFIX = ${BUILD_DIR}/${IOS_ARCH_DIR}
@@ -26,11 +26,8 @@ UTHASHDIR = ${CURDIR}/uthash
 
 CXX = ${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++
 CC = ${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
-#CFLAGS =-target ${IOS_TARGET} -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -mios-version-min=17.0 -Os -fembed-bitcode
 CFLAGS =-target "${IOS_TARGET}${OSX_TARGET}" -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -Os -fembed-bitcode
-#CXXFLAGS =-target ${IOS_TARGET} -stdlib=libc++ -std=c++11 -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -mios-version-min=17.0 -Os -fembed-bitcode
 CXXFLAGS =-target "${IOS_TARGET}${OSX_TARGET}" -stdlib=libc++ -std=c++11 -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -Os -fembed-bitcode
-#LDFLAGS =-stdlib=libc++ -isysroot ${IOS_SDK} -L${LIBDIR} -L${IOS_SDK}/usr/lib -arch ${IOS_ARCH} -mios-version-min=17.0
 LDFLAGS =-stdlib=libc++ -isysroot ${IOS_SDK} -L${LIBDIR} -L${IOS_SDK}/usr/lib -arch ${IOS_ARCH}
 
 arch: ${LIBDIR}/libspatialite.a
@@ -99,7 +96,7 @@ ${LIBDIR}/libproj.a: ${CURDIR}/proj
 	-DENABLE_CURL=OFF \
 	-DENABLE_TIFF=OFF \
 	-DSQLITE3_INCLUDE_DIR=${IOS_SDK}/usr/include \
-	&& cmake  --build . --config Release -j 12 && cmake --install . --config Release
+	&& cmake --build . --config Release -j 12 && cmake --install . --config Release
 
 ${CURDIR}/proj:
 	curl -L https://download.osgeo.org/proj/proj-9.2.1.tar.gz > proj.tar.gz
@@ -116,53 +113,13 @@ ${LIBDIR}/libgeos.a: ${CURDIR}/geos
 	-DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
 	-DCMAKE_OSX_ARCHITECTURES=${IOS_ARCH} \
 	-DCMAKE_OSX_SYSROOT:PATH="${IOS_SDK}" -DBUILD_GEOSOP:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -DBUILD_TESTING:BOOL=OFF \
-	&& cmake  --build . --config Release -j 12 && cmake --install . --config Release
+	&& cmake --build . --config Release -j 12 && cmake --install . --config Release
 
 ${CURDIR}/geos:
 	curl https://download.osgeo.org/geos/geos-3.12.0.tar.bz2 > geos.tar.bz2
 	tar -xzf geos.tar.bz2
 	rm geos.tar.bz2
 	mv geos-3.12.0 geos
-
-
-
-#SQLITE_FLAGS=-DNDEBUG=1 \
-#	-DHAVE_USLEEP=1 \
-#	-DSQLITE_HAVE_ISNAN \
-#	-DSQLITE_DEFAULT_JOURNAL_SIZE_LIMIT=1048576 \
-#	-DSQLITE_THREADSAFE=2 \
-#	-DSQLITE_TEMP_STORE=3 \
-#	-DSQLITE_POWERSAFE_OVERWRITE=1 \
-#	-DSQLITE_DEFAULT_FILE_FORMAT=4 \
-#	-DSQLITE_DEFAULT_AUTOVACUUM=1 \
-#	-DSQLITE_ENABLE_MEMORY_MANAGEMENT=1 \
-#	-DSQLITE_ENABLE_FTS3 \
-#	-DSQLITE_ENABLE_FTS4 \
-#	-DSQLITE_ENABLE_JSON1 \
-#	-DSQLITE_OMIT_BUILTIN_TEST \
-#	-DSQLITE_OMIT_COMPILEOPTION_DIAGS \
-#	-DSQLITE_DEFAULT_FILE_PERMISSIONS=0600 \
-#	-DSQLITE_ENABLE_RTREE \
-#	-DSQLITE_ENABLE_ICU \
-#	-DSQLITE_ENABLE_LOAD_EXTENSION
-#${LIBDIR}/libsqlite3.a: ${CURDIR}/sqlite3 ${LIBDIR}/libicu.a
-#	cd sqlite3 && \
-#	LIBTOOL=${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool \
-#	CXX=${CXX} \
-#	CC=${CC} \
-#	CFLAGS="${CFLAGS}" \
-#	CXXFLAGS="${CXXFLAGS}" \
-#	LDFLAGS="-Wl,-arch -Wl,${IOS_ARCH} -arch_only ${IOS_ARCH} ${LDFLAGS} -licudata -licui18n -licuuc" \
-#	${CC} -c sqlite3.c ${CFLAGS} ${SQLITE_FLAGS} -o "${LIBDIR}/libsqlite3.a"
-#	cp -f -v "${CURDIR}/sqlite3/"*.h ${INCLUDEDIR}
-
-#${CURDIR}/sqlite3:
-#	curl -L https://www.sqlite.org/2023/sqlite-amalgamation-3430200.zip -o sqlite3.zip
-#	unzip sqlite3.zip
-#	rm sqlite3.zip
-#	mv sqlite-amalgamation-3430200 sqlite3
-#	./patch-sqlite3
-#	touch sqlite3
 
 ${LIBDIR}/libicu.a: ${CURDIR}/icu
 	mkdir -p "${CURDIR}/icu/build/${IOS_ARCH_DIR}" && cd "${CURDIR}/icu/build/${IOS_ARCH_DIR}" && \

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ all: build_arches
 build_arches:
 	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=MacOSX OSX_HOST=arm-apple-darwin OSX_TARGET=arm64-apple-macos12.0 IOS_ARCH_DIR=arm64-macos OS_TARGET=Darwin
 	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneOS IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0 IOS_ARCH_DIR=arm64-ios OS_TARGET=iOS
-	#${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0-simulator IOS_ARCH_DIR=arm64-sim OS_TARGET=iOS
-	#${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0-simulator IOS_ARCH_DIR=arm64-sim OS_TARGET=iOS
+#	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0-simulator IOS_ARCH_DIR=arm64-sim OS_TARGET=iOS
 
 BUILD_DIR = ${CURDIR}/build
 PREFIX = ${BUILD_DIR}/${IOS_ARCH_DIR}

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,10 @@ all: build_arches
 # Build separate architectures
 # see https://www.innerfence.com/howto/apple-ios-devices-dates-versions-instruction-sets
 build_arches:
-	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneOS IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0 IOS_ARCH_DIR=arm64-ios
-	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0-simulator IOS_ARCH_DIR=arm64-sim
-	${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0-simulator IOS_ARCH_DIR=arm64-sim
-
-
+	${MAKE} arch OSX_ARCH=arm64 IOS_PLATFORM=MacOSX OSX_HOST=arm-apple-darwin OSX_TARGET=arm64-apple-macos12.0 OSX_ARCH_DIR=arm64-macos
+	#${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneOS IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0 IOS_ARCH_DIR=arm64-ios
+	#${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0-simulator IOS_ARCH_DIR=arm64-sim
+	#${MAKE} arch IOS_ARCH=arm64 IOS_PLATFORM=iPhoneSimulator IOS_HOST=arm-apple-darwin IOS_TARGET=arm64-apple-ios17.0-simulator IOS_ARCH_DIR=arm64-sim
 
 BUILD_DIR = ${CURDIR}/build
 PREFIX = ${BUILD_DIR}/${IOS_ARCH_DIR}
@@ -28,13 +27,16 @@ UTHASHDIR = ${CURDIR}/uthash
 
 CXX = ${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++
 CC = ${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
-CFLAGS =-target ${IOS_TARGET} -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -mios-version-min=17.0 -Os -fembed-bitcode
-CXXFLAGS =-target ${IOS_TARGET} -stdlib=libc++ -std=c++11 -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -mios-version-min=17.0 -Os -fembed-bitcode
-LDFLAGS =-stdlib=libc++ -isysroot ${IOS_SDK} -L${LIBDIR} -L${IOS_SDK}/usr/lib -arch ${IOS_ARCH} -mios-version-min=17.0
+#CFLAGS =-target ${IOS_TARGET} -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -mios-version-min=17.0 -Os -fembed-bitcode
+CFLAGS =-target "${IOS_TARGET}${OSX_TARGET}" -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -Os -fembed-bitcode
+#CXXFLAGS =-target ${IOS_TARGET} -stdlib=libc++ -std=c++11 -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -mios-version-min=17.0 -Os -fembed-bitcode
+CXXFLAGS =-target "${IOS_TARGET}${OSX_TARGET}" -stdlib=libc++ -std=c++11 -isysroot ${IOS_SDK} -I${IOS_SDK}/usr/include -I${INCLUDEDIR} -I${UTHASHDIR} -Os -fembed-bitcode
+#LDFLAGS =-stdlib=libc++ -isysroot ${IOS_SDK} -L${LIBDIR} -L${IOS_SDK}/usr/lib -arch ${IOS_ARCH} -mios-version-min=17.0
+LDFLAGS =-stdlib=libc++ -isysroot ${IOS_SDK} -L${LIBDIR} -L${IOS_SDK}/usr/lib -arch ${IOS_ARCH}
 
 arch: ${LIBDIR}/libspatialite.a
 
-${LIBDIR}/libspatialite.a: ${LIBDIR}/libsqlite3.a ${LIBDIR}/libproj.a ${LIBDIR}/libgeos.a ${LIBDIR}/rttopo.a ${CURDIR}/spatialite
+${LIBDIR}/libspatialite.a: ${LIBDIR}/libproj.a ${LIBDIR}/libgeos.a ${LIBDIR}/rttopo.a ${CURDIR}/spatialite
 	cd spatialite && env \
 	CXX=${CXX} \
 	CC=${CC} \
@@ -97,8 +99,7 @@ ${LIBDIR}/libproj.a: ${CURDIR}/proj
 	-DENABLE_CURL=OFF \
 	-DENABLE_TIFF=OFF \
 	-DSQLITE3_INCLUDE_DIR=${INCLUDEDIR} \
-	-DSQLITE3_LIBRARY=${LIBDIR}/libsqlite3.a \
-	&& cmake --build . --target clean && cmake  --build . --config Release && cmake --install . --config Release
+	&& cmake --build . --target clean && cmake  --build . --config Release -j 12 && cmake --install . --config Release
 
 ${CURDIR}/proj:
 	curl -L https://download.osgeo.org/proj/proj-9.2.1.tar.gz > proj.tar.gz
@@ -115,7 +116,7 @@ ${LIBDIR}/libgeos.a: ${CURDIR}/geos
 	-DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
 	-DCMAKE_OSX_ARCHITECTURES=${IOS_ARCH} \
 	-DCMAKE_OSX_SYSROOT:PATH="${IOS_SDK}" -DBUILD_GEOSOP:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF -DBUILD_TESTING:BOOL=OFF \
-	&& cmake --build . --target clean && cmake  --build . --config Release && cmake --install . --config Release
+	&& cmake --build . --target clean && cmake  --build . --config Release -j 12 && cmake --install . --config Release
 
 ${CURDIR}/geos:
 	curl https://download.osgeo.org/geos/geos-3.12.0.tar.bz2 > geos.tar.bz2
@@ -125,43 +126,43 @@ ${CURDIR}/geos:
 
 
 
-SQLITE_FLAGS=-DNDEBUG=1 \
-	-DHAVE_USLEEP=1 \
-	-DSQLITE_HAVE_ISNAN \
-	-DSQLITE_DEFAULT_JOURNAL_SIZE_LIMIT=1048576 \
-	-DSQLITE_THREADSAFE=2 \
-	-DSQLITE_TEMP_STORE=3 \
-	-DSQLITE_POWERSAFE_OVERWRITE=1 \
-	-DSQLITE_DEFAULT_FILE_FORMAT=4 \
-	-DSQLITE_DEFAULT_AUTOVACUUM=1 \
-	-DSQLITE_ENABLE_MEMORY_MANAGEMENT=1 \
-	-DSQLITE_ENABLE_FTS3 \
-	-DSQLITE_ENABLE_FTS4 \
-	-DSQLITE_ENABLE_JSON1 \
-	-DSQLITE_OMIT_BUILTIN_TEST \
-	-DSQLITE_OMIT_COMPILEOPTION_DIAGS \
-	-DSQLITE_DEFAULT_FILE_PERMISSIONS=0600 \
-	-DSQLITE_ENABLE_RTREE \
-	-DSQLITE_ENABLE_ICU \
-	-DSQLITE_ENABLE_LOAD_EXTENSION
-${LIBDIR}/libsqlite3.a: ${CURDIR}/sqlite3 ${LIBDIR}/libicu.a
-	cd sqlite3 && \
-	LIBTOOL=${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool \
-	CXX=${CXX} \
-	CC=${CC} \
-	CFLAGS="${CFLAGS}" \
-	CXXFLAGS="${CXXFLAGS}" \
-	LDFLAGS="-Wl,-arch -Wl,${IOS_ARCH} -arch_only ${IOS_ARCH} ${LDFLAGS} -licudata -licui18n -licuuc" \
-	${CC} -c sqlite3.c ${CFLAGS} ${SQLITE_FLAGS} -o "${LIBDIR}/libsqlite3.a"
-	cp -f -v "${CURDIR}/sqlite3/"*.h ${INCLUDEDIR}
+#SQLITE_FLAGS=-DNDEBUG=1 \
+#	-DHAVE_USLEEP=1 \
+#	-DSQLITE_HAVE_ISNAN \
+#	-DSQLITE_DEFAULT_JOURNAL_SIZE_LIMIT=1048576 \
+#	-DSQLITE_THREADSAFE=2 \
+#	-DSQLITE_TEMP_STORE=3 \
+#	-DSQLITE_POWERSAFE_OVERWRITE=1 \
+#	-DSQLITE_DEFAULT_FILE_FORMAT=4 \
+#	-DSQLITE_DEFAULT_AUTOVACUUM=1 \
+#	-DSQLITE_ENABLE_MEMORY_MANAGEMENT=1 \
+#	-DSQLITE_ENABLE_FTS3 \
+#	-DSQLITE_ENABLE_FTS4 \
+#	-DSQLITE_ENABLE_JSON1 \
+#	-DSQLITE_OMIT_BUILTIN_TEST \
+#	-DSQLITE_OMIT_COMPILEOPTION_DIAGS \
+#	-DSQLITE_DEFAULT_FILE_PERMISSIONS=0600 \
+#	-DSQLITE_ENABLE_RTREE \
+#	-DSQLITE_ENABLE_ICU \
+#	-DSQLITE_ENABLE_LOAD_EXTENSION
+#${LIBDIR}/libsqlite3.a: ${CURDIR}/sqlite3 ${LIBDIR}/libicu.a
+#	cd sqlite3 && \
+#	LIBTOOL=${XCODE_DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool \
+#	CXX=${CXX} \
+#	CC=${CC} \
+#	CFLAGS="${CFLAGS}" \
+#	CXXFLAGS="${CXXFLAGS}" \
+#	LDFLAGS="-Wl,-arch -Wl,${IOS_ARCH} -arch_only ${IOS_ARCH} ${LDFLAGS} -licudata -licui18n -licuuc" \
+#	${CC} -c sqlite3.c ${CFLAGS} ${SQLITE_FLAGS} -o "${LIBDIR}/libsqlite3.a"
+#	cp -f -v "${CURDIR}/sqlite3/"*.h ${INCLUDEDIR}
 
-${CURDIR}/sqlite3:
-	curl -L https://www.sqlite.org/2023/sqlite-amalgamation-3430200.zip -o sqlite3.zip
-	unzip sqlite3.zip
-	rm sqlite3.zip
-	mv sqlite-amalgamation-3430200 sqlite3
-	./patch-sqlite3
-	touch sqlite3
+#${CURDIR}/sqlite3:
+#	curl -L https://www.sqlite.org/2023/sqlite-amalgamation-3430200.zip -o sqlite3.zip
+#	unzip sqlite3.zip
+#	rm sqlite3.zip
+#	mv sqlite-amalgamation-3430200 sqlite3
+#	./patch-sqlite3
+#	touch sqlite3
 
 ${LIBDIR}/libicu.a: ${CURDIR}/icu
 	mkdir -p "${CURDIR}/icu/build/${IOS_ARCH_DIR}" && cd "${CURDIR}/icu/build/${IOS_ARCH_DIR}" && \
@@ -186,7 +187,7 @@ ${LIBDIR}/libicu.a: ${CURDIR}/icu
 	--enable-samples=no \
 	--enable-dyload=no \
 	--with-data-packaging=archive \
-	&& make clean install
+	&& make -j12 install
 
 ${CURDIR}/icu:
 	curl -L https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-src.tgz -o icu.tgz
@@ -198,4 +199,4 @@ ${CURDIR}/icu:
 
 
 clean:
-	rm -rf build geos proj spatialite include lib rttopo sqlite3 LibSpatialite.xcframework icu
+	rm -rf build geos proj spatialite include lib rttopo sqlite3 libspatialite.xcframework icu

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "libspatialite",
+    platforms: [.iOS(.v17)],
+    products: [
+        .library(name: "libspatialite", targets: ["libspatialite"])
+    ],
+    targets: [
+        .binaryTarget(
+                    name: "libspatialite",
+                    url: "https://github.com/mozi-app/libspatialite-ios/releases/download/v5.1.0/libspatialite.xcframework.zip"
+                ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
   name: "libspatialite",
-  platforms: [.iOS(.v17)],
+  platforms: [.iOS(.v17), .macOS(.v12)],
   products: [
     .library(name: "SpatialiteObjC", type: .dynamic, targets: ["SpatialiteObjC"]),
     .library(name: "libspatialite", targets: ["libspatialite"]),
@@ -11,8 +11,9 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "libspatialite",
-      url: "https://github.com/mozi-app/libspatialite-ios/releases/download/v0.1.0/libspatialite.xcframework.zip",
-      checksum: "f152b53c5c042544ec1d97eb50be1f8d129c6d2b33a2b627322930997ffe24ba"
+      path: "libspatialite.xcframework"
+    //  url: "https://github.com/mozi-app/libspatialite-ios/releases/download/v0.1.0/libspatialite.xcframework.zip",
+    //  checksum: "f152b53c5c042544ec1d97eb50be1f8d129c6d2b33a2b627322930997ffe24ba"
     ),
     .target(
       name: "SpatialiteObjC",
@@ -26,6 +27,7 @@ let package = Package(
         .linkedLibrary("z"),
         .linkedLibrary("iconv"),
         .linkedLibrary("c++"),
+        .linkedLibrary("sqlite3"),
       ]
     ),
   ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "libspatialite",
-      url: "https://github.com/mozi-app/libspatialite-ios/releases/download/v1.0.0/libspatialite.xcframework.zip",
+      url: "https://github.com/mozi-app/libspatialite-ios/releases/download/v0.1.0/libspatialite.xcframework.zip",
       checksum: "f152b53c5c042544ec1d97eb50be1f8d129c6d2b33a2b627322930997ffe24ba"
     ),
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
   targets: [
     .binaryTarget(
       name: "libspatialite",
-      url: "https://github.com/mozi-app/libspatialite-ios/releases/download/v5.1.0/libspatialite.xcframework.zip",
+      url: "https://github.com/mozi-app/libspatialite-ios/releases/download/v1.0.0/libspatialite.xcframework.zip",
       checksum: "f152b53c5c042544ec1d97eb50be1f8d129c6d2b33a2b627322930997ffe24ba"
     ),
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,32 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
-    name: "libspatialite",
-    platforms: [.iOS(.v17)],
-    products: [
-        .library(name: "libspatialite", targets: ["libspatialite"])
-    ],
-    targets: [
-        .binaryTarget(
-                    name: "libspatialite",
-                    url: "https://github.com/mozi-app/libspatialite-ios/releases/download/v5.1.0/libspatialite.xcframework.zip",
-                    checksum: "f152b53c5c042544ec1d97eb50be1f8d129c6d2b33a2b627322930997ffe24ba"
-                ),
-    ]
+  name: "libspatialite",
+  platforms: [.iOS(.v17)],
+  products: [
+    .library(name: "SpatialiteObjC", type: .dynamic, targets: ["SpatialiteObjC"]),
+    .library(name: "libspatialite", targets: ["libspatialite"]),
+  ],
+  targets: [
+    .binaryTarget(
+      name: "libspatialite",
+      url: "https://github.com/mozi-app/libspatialite-ios/releases/download/v5.1.0/libspatialite.xcframework.zip",
+      checksum: "f152b53c5c042544ec1d97eb50be1f8d129c6d2b33a2b627322930997ffe24ba"
+    ),
+    .target(
+      name: "SpatialiteObjC",
+      dependencies: [
+        "libspatialite"
+      ],
+      path: "Sources/SpatialiteObjC",
+      exclude: [],
+      sources: ["LibSpatialite.m"],
+      linkerSettings: [
+        .linkedLibrary("z"),
+        .linkedLibrary("iconv"),
+        .linkedLibrary("c++"),
+      ]
+    ),
+  ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
     targets: [
         .binaryTarget(
                     name: "libspatialite",
-                    url: "https://github.com/mozi-app/libspatialite-ios/releases/download/v5.1.0/libspatialite.xcframework.zip"
+                    url: "https://github.com/mozi-app/libspatialite-ios/releases/download/v5.1.0/libspatialite.xcframework.zip",
+                    checksum: "f152b53c5c042544ec1d97eb50be1f8d129c6d2b33a2b627322930997ffe24ba"
                 ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The resulting library is a "fat" library suitable for multiple architectures. Th
 - armv7s (iOS)
 - arm64 (iOS)
 - i386 (iOS Simulator)
-- x86_64 (iOS Simulator)
 
 Requirements
 ------------

--- a/Sources/SpatialiteObjC/LibSpatialite.m
+++ b/Sources/SpatialiteObjC/LibSpatialite.m
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+#import "include/LibSpatialite.h"
+
+void setupSpatialite(){
+  spatialite_init(0);
+  puts("SpatiaLite integrated");
+}

--- a/Sources/SpatialiteObjC/include/LibSpatialite.h
+++ b/Sources/SpatialiteObjC/include/LibSpatialite.h
@@ -1,0 +1,11 @@
+#ifndef LibSpatialite_h
+#define LibSpatialite_h
+
+#import <spatialite/gaiageo.h>
+#import <spatialite.h>
+
+
+void setupSpatialite();
+
+#endif
+

--- a/make-framework
+++ b/make-framework
@@ -1,17 +1,20 @@
 #!/bin/sh
+
+operationg_systems=(ios macos)
+architectures=(arm64)
     
-pushd lib
-libtool -o libspatialiteall.a mod_spatialite.a
-
-popd
-pushd build/arm64-ios/lib
-libtool -o libspatialiteall.a mod_spatialite.a
-popd
-
-popd
-pushd build/macos-arm64/lib
-libtool -o libspatialiteall.a mod_spatialite.a
-popd
+for arch in "${architectures[@]}"; do
+	for os in "${operationg_systems[@]}"; do
+		if [ -d "build/$arch-$os" ]; then
+			echo "Building $arch-$os"
+			cd "build/$arch-$os/lib"
+			libtool -o libspatialiteall.a *.a
+			cd -
+		else
+			echo "Skipping $arch-$os"
+		fi
+	done
+done
 
 # Make framework
-xcodebuild -create-xcframework -library lib/libspatialiteall.a -headers include/ -library build/arm64-ios/lib/libspatialiteall.a -library build/macos-arm64/lib/libspatialiteall.a -headers include/ -output libspatialite.xcframework
+xcodebuild -create-xcframework -library build/arm64-ios/lib/libspatialiteall.a -library build/macos-arm64/lib/libspatialiteall.a -headers include/ -output libspatialite.xcframework

--- a/make-framework
+++ b/make-framework
@@ -1,11 +1,17 @@
 #!/bin/sh
     
 pushd lib
-libtool -o libspatialiteall.a *.a
+libtool -o libspatialiteall.a mod_spatialite.a
+
 popd
 pushd build/arm64-ios/lib
-libtool -o libspatialiteall.a *.a
+libtool -o libspatialiteall.a mod_spatialite.a
+popd
+
+popd
+pushd build/macos-arm64/lib
+libtool -o libspatialiteall.a mod_spatialite.a
 popd
 
 # Make framework
-xcodebuild -create-xcframework -library lib/libspatialiteall.a -headers include/ -library build/arm64-ios/lib/libspatialiteall.a -headers include/ -output libspatialite.xcframework
+xcodebuild -create-xcframework -library lib/libspatialiteall.a -headers include/ -library build/arm64-ios/lib/libspatialiteall.a -library build/macos-arm64/lib/libspatialiteall.a -headers include/ -output libspatialite.xcframework

--- a/make-framework
+++ b/make-framework
@@ -24,3 +24,5 @@ done
 
 # Make framework
 $command
+
+zip -r libspatialite.xcframework.zip libspatialite.xcframework

--- a/make-framework
+++ b/make-framework
@@ -1,15 +1,21 @@
 #!/bin/sh
 
-operationg_systems=(ios macos)
+rm -rf libspatialite.xcframework
+
+operationg_systems=(ios macos sim)
 architectures=(arm64)
+
+command="xcodebuild -create-xcframework -output libspatialite.xcframework"
     
 for arch in "${architectures[@]}"; do
 	for os in "${operationg_systems[@]}"; do
 		if [ -d "build/$arch-$os" ]; then
 			echo "Building $arch-$os"
 			cd "build/$arch-$os/lib"
+			rm -f libspatialiteall.a
 			libtool -o libspatialiteall.a *.a
 			cd -
+			command="$command -library build/$arch-$os/lib/libspatialiteall.a -headers include/"
 		else
 			echo "Skipping $arch-$os"
 		fi
@@ -17,4 +23,4 @@ for arch in "${architectures[@]}"; do
 done
 
 # Make framework
-xcodebuild -create-xcframework -library build/arm64-ios/lib/libspatialiteall.a -headers include/ -library build/arm64-macos/lib/libspatialiteall.a -headers include/ -output libspatialite.xcframework
+$command

--- a/make-framework
+++ b/make-framework
@@ -17,4 +17,4 @@ for arch in "${architectures[@]}"; do
 done
 
 # Make framework
-xcodebuild -create-xcframework -library build/arm64-ios/lib/libspatialiteall.a -library build/arm64-macos/lib/libspatialiteall.a -headers include/ -output libspatialite.xcframework
+xcodebuild -create-xcframework -library build/arm64-ios/lib/libspatialiteall.a -headers include/ -library build/arm64-macos/lib/libspatialiteall.a -headers include/ -output libspatialite.xcframework

--- a/make-framework
+++ b/make-framework
@@ -17,4 +17,4 @@ for arch in "${architectures[@]}"; do
 done
 
 # Make framework
-xcodebuild -create-xcframework -library build/arm64-ios/lib/libspatialiteall.a -library build/macos-arm64/lib/libspatialiteall.a -headers include/ -output libspatialite.xcframework
+xcodebuild -create-xcframework -library build/arm64-ios/lib/libspatialiteall.a -library build/arm64-macos/lib/libspatialiteall.a -headers include/ -output libspatialite.xcframework

--- a/patch-spatialite
+++ b/patch-spatialite
@@ -4,3 +4,4 @@ patch -Np0 < patches/spatialite.patch
 patch -Np0 < patches/gg_dxf.h.patch
 patch -Np0 < patches/gg_formats.h.patch
 patch -Np0 < patches/gg_structs.h.patch
+patch -Np0 < patches/remove_load_extensions.patch

--- a/patches/remove_load_extensions.patch
+++ b/patches/remove_load_extensions.patch
@@ -1,0 +1,11 @@
+--- spatialite/src/stored_procedures/stored_procedures.c.orig	2025-02-07 13:53:04
++++ spatialite/src/stored_procedures/stored_procedures.c	2025-02-07 13:53:09
+@@ -2062,7 +2062,7 @@
+ 	  return NULL;
+       }
+ #ifndef LOADABLE_EXTENSION
+-    sqlite3_enable_load_extension (handle, 1);
++    //    sqlite3_enable_load_extension (handle, 1);
+ #endif
+     spatialite_internal_init (handle, cache);
+     return handle;

--- a/run_make_framework.sh
+++ b/run_make_framework.sh
@@ -13,7 +13,6 @@ for file in build/arm64-sim/lib/*.a; \
     do name=$(basename $file .a); \
     lipo -create \
         -arch arm64 build/arm64-sim/lib/$name.a \
-        -arch x86_64 build/x86_64/lib/$name.a \
         -output lib/$name.a \
     ; \
     done;


### PR DESCRIPTION
This is a full end-to-end build that no longer builds a custom version of sqlite. Instead, it leverages the system version of sqlite. The resulting xcframework contains all the related code necessary to build and operate with Spatialite (proj, geos, icu, etc) and supports:
 * macOS
 * iOS
 * iOS simulator

This is no longer building any `amd64` stuff, it's 100% `arm64` because we don't need to support anything else.

The resulting output is both a `.xcframework` directory and a `.zip` file containing all of that, suitable for release.